### PR TITLE
Fix signature double pipe

### DIFF
--- a/models/request.go
+++ b/models/request.go
@@ -118,7 +118,12 @@ func (r *FondyRequestObject) Sign(key string, isDebug bool) error {
 
 	final := make([]string, 0, len(preFiltered))
 	for _, k := range keys {
-		final = append(final, preFiltered[k])
+		value := preFiltered[k]
+
+		// Check if the value is not empty before adding it to the final slice
+		if value != "" {
+			final = append(final, value)
+		}
 	}
 
 	s += strings.Join(final, "|")

--- a/models/request.go
+++ b/models/request.go
@@ -118,10 +118,7 @@ func (r *FondyRequestObject) Sign(key string, isDebug bool) error {
 
 	final := make([]string, 0, len(preFiltered))
 	for _, k := range keys {
-		value := preFiltered[k]
-
-		// Check if the value is not empty before adding it to the final slice
-		if value != "" {
+		if value, exists := preFiltered[k]; exists && value != "" {
 			final = append(final, value)
 		}
 	}


### PR DESCRIPTION
When trying to get verification link, it returned the following signature string: 
`test|10000|UAH||600.00|/card verification|1396424|Verification Test|8b0d3234-208c-4308-b698-9b0dab36c296|Y|Y`.
As you can see it contains double pipe right here: `UAH||600.00`.
We need to check for an empty values when generating the signature.